### PR TITLE
Fix openai error handler for streaming

### DIFF
--- a/python/packages/autogen-ext/src/autogen_ext/models/openai/_error_handler_callback.py
+++ b/python/packages/autogen-ext/src/autogen_ext/models/openai/_error_handler_callback.py
@@ -1,7 +1,8 @@
 import asyncio
 import functools
+import inspect
 import logging
-from typing import Any, Callable, Dict, Optional, Tuple, Type, Union
+from typing import Any, AsyncGenerator, Callable, Dict, Optional, Tuple, Type, Union
 
 import openai
 from autogen_core.models import CreateResult, RequestUsage
@@ -13,6 +14,12 @@ logger = logging.getLogger(__name__)
 # - a CreateResult (to let the application proceed), or
 # - None (to signal the decorator to re-raise or retry).
 ErrorCallback = Callable[[Exception], Optional[CreateResult]]
+
+
+class TruncatedCreateResult(CreateResult):
+    """Result emitted when a streaming call ends prematurely."""
+
+    truncated: bool = True
 
 def handle_openai_exceptions(
     retry_exceptions: Tuple[Type[Exception], ...] = (openai.RateLimitError, openai.APIStatusError),
@@ -36,6 +43,53 @@ def handle_openai_exceptions(
         error_callbacks = {}
 
     def decorator(func: Callable) -> Callable:
+        if inspect.isasyncgenfunction(func):
+            @functools.wraps(func)
+            async def agen_wrapper(*args, **kwargs) -> AsyncGenerator[Any, None]:
+                attempts = 0
+                last_error: Optional[Exception] = None
+
+                while attempts <= max_retries:
+                    try:
+                        async for item in func(*args, **kwargs):
+                            yield item
+                        return
+
+                    except Exception as e:
+                        for key, callback in error_callbacks.items():
+                            if isinstance(key, type) and isinstance(e, key):
+                                maybe_result = callback(e)
+                                if maybe_result is not None:
+                                    yield maybe_result
+                                    return
+                                break
+                            if isinstance(key, str) and key in str(e):
+                                maybe_result = callback(e)
+                                if maybe_result is not None:
+                                    yield maybe_result
+                                    return
+                                break
+
+                        if any(isinstance(e, ex) for ex in retry_exceptions):
+                            attempts += 1
+                            if attempts <= max_retries:
+                                sleep_time = backoff_seconds * (2 ** (attempts - 1))
+                                logger.warning(
+                                    f"Retry {attempts}/{max_retries} after error: {e}\n"
+                                    f"Sleeping {sleep_time}s before retry."
+                                )
+                                await asyncio.sleep(sleep_time)
+                                continue
+
+                        last_error = e
+                        break
+
+                if last_error:
+                    raise last_error
+                raise RuntimeError("Reached an unexpected state in error handling.")
+
+            return agen_wrapper
+
         @functools.wraps(func)
         async def wrapper(*args, **kwargs) -> Any:
             attempts = 0
@@ -56,7 +110,6 @@ def handle_openai_exceptions(
                             maybe_result = callback(e)
                             if maybe_result is not None:
                                 return maybe_result
-                            # If callback returns None, we re-raise or retry.
                             break
                         # 2) If the key is a string and it appears in the error message.
                         if isinstance(key, str) and key in str(e):
@@ -65,7 +118,6 @@ def handle_openai_exceptions(
                                 return maybe_result
                             break
 
-                    # If the exception type is in retry_exceptions, we attempt a retry.
                     if any(isinstance(e, ex) for ex in retry_exceptions):
                         attempts += 1
                         if attempts <= max_retries:
@@ -75,18 +127,14 @@ def handle_openai_exceptions(
                                 f"Sleeping {sleep_time}s before retry."
                             )
                             await asyncio.sleep(sleep_time)
-                            continue  # Retry the original function.
+                            continue
 
-                    # Otherwise, we have no fallback or we've exhausted retries, so store & break.
                     last_error = e
                     break
 
-            # If we reach here, either:
-            # - We exhausted all retries, OR
-            # - No callback or retry logic applied.
             if last_error:
                 raise last_error
-            raise RuntimeError("Reached an unexpected state in error handling.")  # Failsafe
+            raise RuntimeError("Reached an unexpected state in error handling.")
 
         return wrapper
     return decorator


### PR DESCRIPTION
## Summary
- support async generator functions in handle_openai_exceptions
- add `TruncatedCreateResult` as placeholder for truncated stream errors
- use new error handling in tests

## Testing
- `python/.venv/bin/pytest python/packages/autogen-ext/tests/models/test_content_filter_callback -q`
- `python/.venv/bin/pytest python/packages/autogen-ext/tests/models/test_openai_model_client.py::test_openai_chat_completion_client_create_stream_with_usage -q`
